### PR TITLE
Remove 'View' Button

### DIFF
--- a/reactapp/src/components/asset-results-item/index.jsx
+++ b/reactapp/src/components/asset-results-item/index.jsx
@@ -15,7 +15,6 @@ const useStyles = makeStyles({
     width: 200,
     margin: '1rem',
     position: 'relative',
-    paddingBottom: '2rem'
   },
   media: {
     height: 200
@@ -55,11 +54,6 @@ export default function AssetItem({
           </CardContent>
         </Link>
       </CardActionArea>
-      <CardActions className={classes.actions}>
-        <Button size="small" color="primary">
-          <Link to={routes.viewAssetWithVar.replace(':assetId', id)}>View</Link>
-        </Button>
-      </CardActions>
     </Card>
   )
 }


### PR DESCRIPTION
(Possibly a controversial change, feel free to reject)
Removes the 'View' button.

I don't think it added much to the UI, and it rendered weirdly with mouseover highlights anyway.

looks like this:
![](https://cdn.discordapp.com/attachments/647227941972869126/712642607934603354/unknown.png)