### PR TITLE
Added Avali download links

### DIFF
--- a/reactapp/src/species-meta.js
+++ b/reactapp/src/species-meta.js
@@ -36,6 +36,8 @@ They were originally a [RimWorld mod](https://rimworldbase.com/avali-mod/) but h
 Useful links:
 - [The Official Avali Wiki](https://avali.fandom.com/wiki/The_Official_Avali_Wiki)`,
     thumbnailUrl: avaliImageUrl
+  [Reverse Avali Download](https://vrcmods.com/item/5305)
+  [Avali 1.1 Download](https://vrcmods.com/item/3457)
   },
   [species.BestBoi]: {
     name: 'Best Boi',


### PR DESCRIPTION
I followed the syntax for hyperlinks from the "RimWorld mod" text, not sure if its the same cus its orange now