### PR TITLE
Fix 'Accessories' not being clickable.

### DIFF
--- a/reactapp/src/components/header/index.jsx
+++ b/reactapp/src/components/header/index.jsx
@@ -84,7 +84,7 @@ const useStyles = makeStyles({
     position: 'absolute',
     top: 0,
     left: 0,
-    padding: '1rem',
+    margin: '1rem',
     [mediaQueryForMobiles]: {
       position: 'relative',
       padding: 0


### PR DESCRIPTION
change logo margin to padding to not overlap touch targets.

Fixes #19